### PR TITLE
Fix/v1.0.1/#1

### DIFF
--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -24,9 +24,8 @@ public class CSVReader {
             String line;
             int lineNumber = 1;
             while ((line = reader.readLine()) != null) {
-                lineNumber++;
                 try {
-                    Schedule s = scheduleFromCSVString(lineNumber, line);
+                    Schedule s = scheduleFromCSVString(line);
                     scheduleList.add(s);
                 } catch (Exception e) {
                     log.warning(lineMessage(lineNumber) + e.getMessage());
@@ -39,7 +38,7 @@ public class CSVReader {
         return scheduleList;
     }
 
-    private static Schedule scheduleFromCSVString(int lineNumber, String line) {
+    private static Schedule scheduleFromCSVString(String line) {
         String[] parts = line.split("\\|");
 
         String title = parts[0].trim();
@@ -54,7 +53,7 @@ public class CSVReader {
             case "금" -> DayOfWeek.FRIDAY.toString();
             case "토" -> DayOfWeek.SATURDAY.toString();
             case "일" -> DayOfWeek.SUNDAY.toString();
-            default -> throw new IllegalArgumentException(lineMessage(lineNumber) + "Illegal dayOfWeek [" + dayOfWeekStr + "]. Write it correctly in [월,화,수,목,금,토,일].");
+            default -> throw new IllegalArgumentException("Illegal dayOfWeek [" + dayOfWeekStr + "]. Write it correctly in [월,화,수,목,금,토,일].");
         };
         String startTimeStr = parts[4].trim();
         String endTimeStr = parts[5].trim();

--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -10,8 +10,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Log
 public class CSVReader {
@@ -42,18 +40,12 @@ public class CSVReader {
     }
 
     private static Schedule scheduleFromCSVString(int lineNumber, String line) {
-        Pattern pattern = Pattern.compile("\"([^\"]*)\"|([^,]+)");
-        Matcher matcher = pattern.matcher(line);
+        String[] parts = line.split("\\|");
 
-        String[] parts = new String[6];
-        for (int i = 0; i < parts.length && matcher.find(); i++) {
-            parts[i] = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
-        }
-
-        String titleStr = parts[0];
-        String startDateStr = parts[1];
-        String endDateStr = parts[2];
-        String dayOfWeekStr = parts[3];
+        String title = parts[0].trim();
+        String startDateStr = parts[1].trim();
+        String endDateStr = parts[2].trim();
+        String dayOfWeekStr = parts[3].trim();
         dayOfWeekStr = switch (dayOfWeekStr) {
             case "월" -> DayOfWeek.MONDAY.toString();
             case "화" -> DayOfWeek.TUESDAY.toString();
@@ -64,10 +56,9 @@ public class CSVReader {
             case "일" -> DayOfWeek.SUNDAY.toString();
             default -> throw new IllegalArgumentException(lineMessage(lineNumber) + "Illegal dayOfWeek [" + dayOfWeekStr + "]. Write it correctly in [월,화,수,목,금,토,일].");
         };
-        String startTimeStr = parts[4];
-        String endTimeStr = parts[5];
+        String startTimeStr = parts[4].trim();
+        String endTimeStr = parts[5].trim();
 
-        String title = titleStr.replaceAll("\"", "");
         LocalDate startDate = LocalDate.parse(startDateStr);
         LocalDate endDate = LocalDate.parse(endDateStr);
         DayOfWeek dayOfWeek = DayOfWeek.valueOf(dayOfWeekStr);


### PR DESCRIPTION
버그 수정

1. 구분자를 콤마(,)로 할 경우 일정 제목에 들어가는 콤마(,)와 혼동되므로 구분자를 파이프(|)로 변경함
2. 파이프(|)로 구분되는 각 값들의 앞뒤 공백을 제거하는 로직을 추가하여 공백이 있으면 오류가 발생했던 문제를 해결
3. "요일" 값 파싱 에러 시 라인 번호가 2번 출력되는 버그를 수정
4. 각 라인이 1씩 밀려서 표기됐던 버그를 수정