### PR TITLE
v1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-
-src/main/resources/data.csv
+**/src/main/resources
 
 ### IntelliJ IDEA ###
 .idea

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## 현재 버전
 
-**v1.1.0**
+**v1.1.1**
 
 ## 프로젝트 소개
 
-이 프로젝트는 중복 일정 체크를 쉽게 해주는 기능을 갖추고 있습니다. 장소 대여와 같이 서로의 일정이 겹치지 않는지 체크할 때 유용하게 사용될 수 있습니다.
+&nbsp;&nbsp; 이 프로젝트는 중복 일정 체크를 쉽게 해주는 기능을 갖추고 있습니다. 장소 대여와 같이 서로의 일정이 겹치지 않는지 체크할 때 유용하게 사용될 수 있습니다.
 
 ## 사용 방법
 
@@ -18,11 +18,11 @@
 
 ### data.csv 파일 생성
 
-경로: `src/main/resources/data.csv`
+- 경로: `src/main/resources/data.csv`
 
 ### data.csv 파일 작성
 
-모든 일정을 data.csv 파일에 작성한다.  
+&nbsp;&nbsp; 모든 일정을 data.csv 파일에 작성한다.  
 
 > **형식**
 > 
@@ -38,27 +38,35 @@
 Example:
 
    ```csv
-   [2청] 밴드 소모임|2024-02-01|2099-12-31|월|20:00|22:00
+   [2청] 김종순 소모임|2024-02-01|2099-12-31|월|20:00|22:00
    [2청] 기초반|2024-03-14|2024-05-16|목|19:30|22:30
    [2청] 큐티반|2024-03-13|2024-05-08|수|10:00|12:30
    [2청] 내가 보는 세상, 세상이 보는 나|2024-03-16|2024-05-25|토|19:30|22:00
+   [2청] 안내팀 모임|2024-03-02|2024-03-02|토|14:00|23:59
+   [2청] 홀챌|2024-03-19|2024-03-19|화|20:00|21:00
+   [2청] 목자모임|2024-04-14|2024-04-14|일|18:10|20:00
+   [2청] 우동목장 아웃팅|2024-03-17|2024-03-17|일|18:15|23:59
    ```
 
 ### 프로젝트 실행
 
-프로젝트를 실행한다. 실행 파일은 `src/main/java/com/dongs/Main.java`
+&nbsp;&nbsp; 프로젝트를 실행한다. 실행 파일은 `src/main/java/com/dongs/Main.java`
 
 ### 프로젝트 결과 확인
 
 #### Success
 
-콘솔에 아무런 에러 로그 없이 `Finish!` 문구만 출력된다면, 모든 일정이 겹치지 않는다는 뜻이다.
+&nbsp;&nbsp; 콘솔에 아무런 에러 메시지 없이 `Finish!` 문구만 출력된다면, 모든 일정이 겹치지 않는다는 뜻이다.
 
 #### Fail
 
-콘솔에 에러 로그가 표시된다. 라인 넘버를 확인하여 어느 줄의 데이터에 오류가 발생했는지 확인할 수 있다.
+&nbsp;&nbsp; 콘솔에 에러 메시지가 표시된다. 라인 넘버를 확인하여 어느 줄의 데이터에 오류가 발생했는지 확인할 수 있다.
 
-|    에러 유형     |                                                      로그 예                                                      |
-|:------------:|:--------------------------------------------------------------------------------------------------------------:|
-| 날짜, 시간 형식 오류 |       <span style="color:red">WARNING: Line 3: Text '2024ㅇ-03-13' could not be parsed at index 4</span>        |
-|   요일 입력 오류   | <span style="color:red">WARNING: Line 3: Illegal dayOfWeek [수4]. Write it correctly in [월,화,수,목,금,토,일].</span> |
+|    에러 유형     |                                                        로그 예                                                        |
+|:------------:|:------------------------------------------------------------------------------------------------------------------:|
+|  데이터 개수 부족   |                           Illegal data! Please fill in the appropriate data in the form                            |
+| 날짜, 시간 형식 오류 | Illegal data! The date or time format is incorrect. The date format is 'yyyy-MM-dd' and the time format is 'hh:mm' |
+|   날짜 순서 오류   |                          Illegal startDate and endDate! startDate must be before endDate                           |
+|   요일 입력 오류   |                           Illegal dayOfWeek [수4]. Write it correctly in [월,화,수,목,금,토,일].                           |
+|  일정 끝 날짜 오류  |                                  Illegal endDate [2024-03-17]. It's already over                                   |
+|   시간 순서 오류   |                          Illegal startTime and endTime! startTime must be before endTime                           |

--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -2,9 +2,9 @@ package com.dongs.scheduler;
 
 import lombok.extern.java.Log;
 
-import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.LineNumberReader;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -20,11 +20,10 @@ public class CSVReader {
     public static List<Schedule> readSchedulesFromCSV(String filePath) {
         List<Schedule> scheduleList = new ArrayList<>();
 
-        try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
+        try (LineNumberReader reader = new LineNumberReader(new FileReader(filePath))) {
             String line;
-            int lineNumber = 0;
             while ((line = reader.readLine()) != null) {
-                lineNumber++;
+                int lineNumber = reader.getLineNumber();
                 try {
                     Schedule s = scheduleFromCSVString(line);
                     scheduleList.add(s);

--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -69,6 +69,10 @@ public class CSVReader {
             throw new IllegalArgumentException("Illegal startDate and endDate! startDate must be before endDate");
         }
 
+        if (isInvalidDayOfWeek(startDate, endDate, dayOfWeek)) {
+            throw new IllegalArgumentException("Illegal dayOfWeek! dayOfWeek must exist between startDate and endDate");
+        }
+
         if (isInvalidDate(LocalDate.now(), endDate)) {
             throw new IllegalArgumentException("Illegal endDate [" + endDateStr + "]. It's already over");
         }
@@ -82,6 +86,11 @@ public class CSVReader {
 
     private static boolean isInvalidDate(LocalDate before, LocalDate after) {
         return before.isAfter(after);
+    }
+
+    private static boolean isInvalidDayOfWeek(LocalDate startDate, LocalDate endDate, DayOfWeek dayOfWeek) {
+        return startDate.datesUntil(endDate.plusDays(1))
+                .noneMatch(d -> d.getDayOfWeek() == dayOfWeek);
     }
 
     private static boolean isInvalidTime(LocalTime before, LocalTime after) {

--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -57,7 +57,7 @@ public class CSVReader {
         }
 
         if (isInvalidDate(LocalDate.now(), endDate)) {
-            throw new IllegalArgumentException("Illegal endDate [" + parts[2].trim() + "]. It's already over");
+            throw new IllegalArgumentException("Illegal endDate [%s]. It's already over".formatted(parts[2].trim()));
         }
 
         if (isInvalidTime(startTime, endTime)) {
@@ -76,7 +76,7 @@ public class CSVReader {
             case "금" -> DayOfWeek.FRIDAY;
             case "토" -> DayOfWeek.SATURDAY;
             case "일" -> DayOfWeek.SUNDAY;
-            default -> throw new IllegalArgumentException("Illegal dayOfWeek [" + dayOfWeekStr + "]. Write it correctly in [월,화,수,목,금,토,일]");
+            default -> throw new IllegalArgumentException("Illegal dayOfWeek [%s]. Write it correctly in [월,화,수,목,금,토,일]".formatted(dayOfWeekStr));
         };
     }
 
@@ -94,6 +94,6 @@ public class CSVReader {
     }
 
     private static String lineMessage(int num) {
-        return "Line " + num + ": ";
+        return "Line %d: ".formatted(num);
     }
 }

--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -33,7 +33,7 @@ public class CSVReader {
                 }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            log.warning(e.getMessage());
         }
 
         return scheduleList;
@@ -43,27 +43,11 @@ public class CSVReader {
         String[] parts = line.split("\\|");
 
         String title = parts[0].trim();
-        String startDateStr = parts[1].trim();
-        String endDateStr = parts[2].trim();
-        String dayOfWeekStr = parts[3].trim();
-        dayOfWeekStr = switch (dayOfWeekStr) {
-            case "월" -> DayOfWeek.MONDAY.toString();
-            case "화" -> DayOfWeek.TUESDAY.toString();
-            case "수" -> DayOfWeek.WEDNESDAY.toString();
-            case "목" -> DayOfWeek.THURSDAY.toString();
-            case "금" -> DayOfWeek.FRIDAY.toString();
-            case "토" -> DayOfWeek.SATURDAY.toString();
-            case "일" -> DayOfWeek.SUNDAY.toString();
-            default -> throw new IllegalArgumentException("Illegal dayOfWeek [" + dayOfWeekStr + "]. Write it correctly in [월,화,수,목,금,토,일]");
-        };
-        String startTimeStr = parts[4].trim();
-        String endTimeStr = parts[5].trim();
-
-        LocalDate startDate = LocalDate.parse(startDateStr);
-        LocalDate endDate = LocalDate.parse(endDateStr);
-        DayOfWeek dayOfWeek = DayOfWeek.valueOf(dayOfWeekStr);
-        LocalTime startTime = LocalTime.parse(startTimeStr);
-        LocalTime endTime = LocalTime.parse(endTimeStr);
+        LocalDate startDate = LocalDate.parse(parts[1].trim());
+        LocalDate endDate = LocalDate.parse(parts[2].trim());
+        DayOfWeek dayOfWeek = getDayOfWeek(parts[3].trim());
+        LocalTime startTime = LocalTime.parse(parts[4].trim());
+        LocalTime endTime = LocalTime.parse(parts[5].trim());
 
         if (isInvalidDate(startDate, endDate)) {
             throw new IllegalArgumentException("Illegal startDate and endDate! startDate must be before endDate");
@@ -74,7 +58,7 @@ public class CSVReader {
         }
 
         if (isInvalidDate(LocalDate.now(), endDate)) {
-            throw new IllegalArgumentException("Illegal endDate [" + endDateStr + "]. It's already over");
+            throw new IllegalArgumentException("Illegal endDate [" + parts[2].trim() + "]. It's already over");
         }
 
         if (isInvalidTime(startTime, endTime)) {
@@ -82,6 +66,19 @@ public class CSVReader {
         }
 
         return Schedule.of(title, dayOfWeek, startTime, endTime, startDate, endDate);
+    }
+
+    private static DayOfWeek getDayOfWeek(String dayOfWeekStr) {
+        return switch (dayOfWeekStr) {
+            case "월" -> DayOfWeek.MONDAY;
+            case "화" -> DayOfWeek.TUESDAY;
+            case "수" -> DayOfWeek.WEDNESDAY;
+            case "목" -> DayOfWeek.THURSDAY;
+            case "금" -> DayOfWeek.FRIDAY;
+            case "토" -> DayOfWeek.SATURDAY;
+            case "일" -> DayOfWeek.SUNDAY;
+            default -> throw new IllegalArgumentException("Illegal dayOfWeek [" + dayOfWeekStr + "]. Write it correctly in [월,화,수,목,금,토,일]");
+        };
     }
 
     private static boolean isInvalidDate(LocalDate before, LocalDate after) {

--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -31,7 +31,7 @@ public class CSVReader {
                     Schedule s = scheduleFromCSVString(line);
                     scheduleList.add(s);
                 } catch (Exception e) {
-                    log.warning(lineMessage(lineNumber) + e.getMessage());
+                    log.warning(lineMessage(lineNumber, e.getMessage()));
                 }
             }
         } catch (IOException e) {
@@ -113,7 +113,7 @@ public class CSVReader {
         return before.isAfter(after);
     }
 
-    private static String lineMessage(int num) {
-        return "Line %d: ".formatted(num);
+    private static String lineMessage(int num, String msg) {
+        return "Line %d: %s".formatted(num, msg);
     }
 }

--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -24,7 +24,7 @@ public class CSVReader {
         try (LineNumberReader reader = new LineNumberReader(new FileReader(filePath))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                if (isAnnotation(line)) continue;
+                if (line.isBlank() || isAnnotation(line)) continue;
 
                 int lineNumber = reader.getLineNumber();
                 try {

--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -23,6 +23,8 @@ public class CSVReader {
         try (LineNumberReader reader = new LineNumberReader(new FileReader(filePath))) {
             String line;
             while ((line = reader.readLine()) != null) {
+                if (isAnnotation(line)) continue;
+
                 int lineNumber = reader.getLineNumber();
                 try {
                     Schedule s = scheduleFromCSVString(line);
@@ -36,6 +38,10 @@ public class CSVReader {
         }
 
         return scheduleList;
+    }
+
+    private static boolean isAnnotation(String line) {
+        return line.startsWith("//");
     }
 
     private static Schedule scheduleFromCSVString(String line) {

--- a/src/main/java/com/dongs/scheduler/CSVReader.java
+++ b/src/main/java/com/dongs/scheduler/CSVReader.java
@@ -8,6 +8,7 @@ import java.io.LineNumberReader;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,12 +48,25 @@ public class CSVReader {
     private static Schedule scheduleFromCSVString(String line) {
         String[] parts = line.split("\\|");
 
-        String title = parts[0].trim();
-        LocalDate startDate = LocalDate.parse(parts[1].trim());
-        LocalDate endDate = LocalDate.parse(parts[2].trim());
-        DayOfWeek dayOfWeek = getDayOfWeek(parts[3].trim());
-        LocalTime startTime = LocalTime.parse(parts[4].trim());
-        LocalTime endTime = LocalTime.parse(parts[5].trim());
+        String title;
+        LocalDate startDate;
+        LocalDate endDate;
+        DayOfWeek dayOfWeek;
+        LocalTime startTime;
+        LocalTime endTime;
+
+        try {
+            title = parts[0].trim();
+            startDate = LocalDate.parse(parts[1].trim());
+            endDate = LocalDate.parse(parts[2].trim());
+            dayOfWeek = getDayOfWeek(parts[3].trim());
+            startTime = LocalTime.parse(parts[4].trim());
+            endTime = LocalTime.parse(parts[5].trim());
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new IllegalArgumentException("Illegal data! Please fill in the appropriate data in the form");
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Illegal data! The date or time format is incorrect. The date format is 'yyyy-MM-dd' and the time format is 'hh:mm'");
+        }
 
         if (isInvalidDate(startDate, endDate)) {
             throw new IllegalArgumentException("Illegal startDate and endDate! startDate must be before endDate");

--- a/src/main/java/com/dongs/scheduler/DefaultScheduler.java
+++ b/src/main/java/com/dongs/scheduler/DefaultScheduler.java
@@ -60,11 +60,11 @@ class DefaultScheduler extends EnumMap<DayOfWeek, Set<Schedule>> implements Sche
         LocalDate s2StartDate = s2.getStartDate();
         LocalDate s2EndDate = s2.getEndDate();
 
-        if (s2StartDate.isAfter(s1EndDate) || s2StartDate.isEqual((s1EndDate))) {
+        if (s2StartDate.isAfter(s1EndDate)) {
             return false;
         }
 
-        if (s2EndDate.isBefore(s1StartDate) || s2EndDate.isEqual(s1StartDate)) {
+        if (s2EndDate.isBefore(s1StartDate)) {
             return false;
         }
 

--- a/src/main/java/com/dongs/scheduler/DefaultScheduler.java
+++ b/src/main/java/com/dongs/scheduler/DefaultScheduler.java
@@ -42,7 +42,7 @@ class DefaultScheduler extends EnumMap<DayOfWeek, Set<Schedule>> implements Sche
 
             for (Schedule sch : scheduleSet) {
                 if (isClash(sch, schedule)) {
-                    log.info("[Clash] " + schedule.getTitle() + " is impossible. cause: " + sch);
+                    log.info("[Clash] \"%s\" is impossible. cause: %s".formatted(schedule.getTitle(), sch));
                     clash = true;
                     break;
                 }

--- a/src/main/java/com/dongs/scheduler/Schedule.java
+++ b/src/main/java/com/dongs/scheduler/Schedule.java
@@ -30,7 +30,7 @@ public class Schedule implements Comparable<Schedule> {
     }
 
     public String toString() {
-        return "[" + title + " " + startDate + " ~ " + endDate + " (" + dayOfWeek + ") " + startTime + " ~ " + endTime + "]";
+        return "[%s %s ~ %s (%s) %s ~ %s]".formatted(title, startDate, endDate, dayOfWeek, startTime, endTime);
     }
 
     @Override


### PR DESCRIPTION
주요 변경 사항

- 일정 충돌 시 에러 메시지의 일정 제목에 쌍따옴표(")를 통해 어떤 일정이 불가능한지 명확하게 표현하도록 함
- data.csv 파일 내 주석, 빈 줄 사용 가능 (// 로 시작하면 주석으로 인식)
- 에러 메시지 세분화

버그 수정

- "요일" 값이 "시작 날짜"와 "끝 날짜" 사이에 존재할 수 없는 값인 경우 에러로 판단하도록 함
- "시작 날짜"와 "끝 날짜" 값이 같은 경우 날짜 검증이 제대로 이뤄지지 않는 문제를 해결
- data.csv 파일에 빈 줄이 있을 경우 데이터 에러로 판단하는 문제를 수정
- data.csv 파일 내 주석을 에러로 판단하는 문제를 수정

주요 리팩토링

- 문자열 합 대신 String 클래스의 formatted() 메서드 적극 활용
- BufferedReader 클래스 대신 줄 번호 값을 계산하는 LineNumberReader 클래스를 활용

그 외

- src/main/resources 폴더 자체를 .gitignore 파일에 추가함 (향후 파일이 추가될 것을 고려)